### PR TITLE
Fix unit tests windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Auto detect text files and perform LF normalization
+* text eol=lf
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain


### PR DESCRIPTION
Unit tests did not pass on Windows due to differences in line endings (CRLF vs. LF) and file paths ('\\' vs '/'). Both of these have been addressed.