### PR TITLE
Fix karma coverage issues

### DIFF
--- a/lib/karma/KarmaCodeSpecsMatcher.js
+++ b/lib/karma/KarmaCodeSpecsMatcher.js
@@ -119,15 +119,13 @@ KarmaCodeSpecsMatcher.prototype._parseXMLCoverageFile = function(xmlCoverageFile
     var self = this,
         deferred = Q.defer();
 
-    try {
-        IOUtils.readFileEventually(xmlCoverageFile, self._config.karma.waitForCoverageTime * 1000)
-            .done(function(xmlData) {
-                deferred.resolve(self._parseXMLCoverageData(xmlData));
-            });
-    } catch(error) {
-        logger.warn("An error occurred while parsing XML coverage file: %s", error);
-        deferred.reject(error);
-    }
+    IOUtils.readFileEventually(xmlCoverageFile, self._config.karma.waitForCoverageTime * 1000)
+        .done(function(xmlData) {
+            deferred.resolve(self._parseXMLCoverageData(xmlData));
+        }, function(error) {
+            logger.warn("An error occurred while parsing XML coverage file: %s", error.message);
+            deferred.reject(error);
+        });
 
     return deferred.promise;
 };
@@ -265,8 +263,12 @@ KarmaCodeSpecsMatcher.prototype._findCodeSpecsUsingCoverage = function() {
 
             deferred.resolve(self._getAbsoluteSpecPaths(codeSpecs));
         }, function(error) {
+            logger.warn('Could not match code with specs: %s', error.message);
             deferred.reject(error);
         });
+    }, function(error) {
+        logger.warn('Could not find base file coverage: %s', error.message);
+        deferred.reject(error);
     });
 
     return deferred.promise;

--- a/lib/karma/KarmaCodeSpecsMatcher.js
+++ b/lib/karma/KarmaCodeSpecsMatcher.js
@@ -51,20 +51,29 @@ KarmaCodeSpecsMatcher.prototype._getSpecFileCoverage = function(specFile) {
             coverageReporter: {
                 type: 'cobertura',
                 dir: self._coverageDir,
-                subdir: '.',
-                file: (specFile ? specFile : 'dummy') + 'coverage.xml'
+                file: (specFile ? specFile : 'dummy') + '.coverage.xml'
             }
-        }),
-        coverageFile = path.join(config.coverageReporter.dir, config.coverageReporter.file);
+        });
 
     self._serverManager.startNewInstance(config).done(function(instance) {
         instance.runTests().done(function() {
-            self._parseXMLCoverageFile(coverageFile).then(function(fileLineCoverage) {
-                instance.stop();
-                deferred.resolve(fileLineCoverage);
-            }, function(error) {
-                deferred.reject(error);
-            });
+            var fileName = path.basename(config.coverageReporter.file),
+                maxWait = self._config.karma.waitForCoverageTime * 1000;
+
+            IOUtils.findEventually(fileName, config.coverageReporter.dir, -1, maxWait)
+                .done(function(coverageFile) {
+                    coverageFile = IOUtils.normalizeWindowsPath(coverageFile);
+                    self._parseXMLCoverageFile(coverageFile).then(function(fileLineCoverage) {
+                        instance.stop();
+                        deferred.resolve(fileLineCoverage);
+                    }, function(error) {
+                        logger.warn('Could not parse the XML coverage file: %s', error);
+                        deferred.reject(error);
+                    });
+                }, function(error) {
+                    logger.warn('Coverage file (%s) not found after %dms: %s', fileName, maxWait, error.message);
+                    deferred.reject(error);
+                });
         });
     });
 
@@ -119,7 +128,7 @@ KarmaCodeSpecsMatcher.prototype._parseXMLCoverageFile = function(xmlCoverageFile
     var self = this,
         deferred = Q.defer();
 
-    IOUtils.readFileEventually(xmlCoverageFile, self._config.karma.waitForCoverageTime * 1000)
+    IOUtils.promiseToReadFile(xmlCoverageFile)
         .done(function(xmlData) {
             deferred.resolve(self._parseXMLCoverageData(xmlData));
         }, function(error) {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,9 @@
     "grunt-karma": "~0.8.3",
     "grunt-mocha-test": "~0.11.0",
     "jshint-stylish": "~0.1.5",
+    "karma": "~0.12.16",
     "karma-chai": "~0.1.0",
+    "karma-coverage": "~0.2.7",
     "karma-mocha": "~0.1.4",
     "karma-phantomjs-launcher": "~0.1.4",
     "load-grunt-tasks": "~0.3.0"
@@ -52,8 +54,6 @@
     "grunt-shell": "~0.7.0",
     "handlebars": "^3.0.0",
     "istanbul": "~0.3.0",
-    "karma": "~0.12.16",
-    "karma-coverage": "^0.2.7",
     "lodash": "~2.4.1",
     "log4js": "^0.6.24",
     "mocha": "~1.20.1",

--- a/tasks/mutation-testing-karma.js
+++ b/tasks/mutation-testing-karma.js
@@ -63,6 +63,18 @@ exports.init = function(grunt, opts) {
                 .findCodeSpecs().then(function(codeSpecs) {
                     fileSpecs = codeSpecs;
                     callback();
+                }, function(error) {
+                    logger.warn('Code could not be automatically matched with specs: %s', error.message);
+                    logger.warn(
+                        'It is still possible to manually provide the code-specs mappings. As a fallback, all tests ' +
+                        'will be run against all code'
+                    );
+
+                    _.forEach(opts.code, function(codeFile) {
+                        fileSpecs[codeFile] = opts.specs;
+                    });
+                    logger.debug('Using code-specs mappings: %j', fileSpecs);
+                    callback();
                 });
         }
 

--- a/utils/IOUtils.js
+++ b/utils/IOUtils.js
@@ -102,9 +102,9 @@ module.exports.readFileEventually = function(fileName, maxWait, interval) {
 /**
  * Try to find a file eventually. Keep trying every (interval || 100) milliseconds.
  *
- * @param fileName {string}
- * @param path {string}
- * @param maxDepth {number=}
+ * @param fileName {string} name of the file that should be found
+ * @param path {string} path to the directory in which the file should be found
+ * @param maxDepth {number=} maximum directory depth for finding the file. When undefined or negative, it will continue indefinitely
  * @param maxWait {number=} maximum time that should be waited for the file to be read
  * @param interval {number=} [interval] number of milliseconds between each try, DEFAULT: 100
  * @returns {promise|*|Q.promise} a promise that will resolve with the file contents or rejected with any error


### PR DESCRIPTION
I've come to the conclusion that we shouldn't have Karma (nor KarmaCoverage) in our 'regular' dependencies after all. By having it there, only the Karma plugins installed in our project are available for use, e.g. KarmaJasmine would be unavailable.

Instead, I have now moved Karma (and KarmaCoverage) to the devDependencies. This does introduce a few issues, however, as we can no longer be sure if and what versions of Karma and KarmaCoverage the user has installed. Luckily, node will show relatively clear error messages when either Karma or KarmaCoverage is not installed, so this is not really an issue. What _is_ an issue, is the fact that we cannot assume that the right version of KarmaCoverage is installed (if you remember, the 0.1.x versions do not allow for complete specification of the path to the coverage file, which is an issue since we need to know that path). To mitigate this, I've introduced a function that will recursively look for the coverage file in the coverage directory, which I have tested and seen working with both v0.1 and v0.2.

In the long term, we should add Karma and KarmaCoverage to the peerDependencies of the project. This way, we can ensure that the user has the right versions of these modules installed next to the grunt-mutation-testing module. For now, it seemed like a bad idea to enforce these modules for all users, as some will only use the project for mutation testing with mocha.