### PR TITLE
Improve ignore

### DIFF
--- a/.mutation-testing-conf.js
+++ b/.mutation-testing-conf.js
@@ -1,1 +1,1 @@
-exports.ignore = [/^console.log\(/, /^function/];
+exports.ignore = [/^\s*console.log\(/, /^function/];

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,7 +45,6 @@ module.exports = function (grunt) {
                 mutate: 'mocha/script*.js',
 
                 testFramework: 'mocha',
-                ignore: [/use strict/],
 
                 logLevel: 'WARN',
                 maxReportedMutationLength: 0,
@@ -238,6 +237,7 @@ module.exports = function (grunt) {
                     code: ['mocha/unaryExpression.js', chaiCode],
                     specs: 'mocha/unaryExpression-test.js',
                     mutate: 'mocha/unaryExpression.js',
+                    mutateStrictModeKeyword: true,
                     reporters: {
                         text: {
                             file: 'unaryExpression.txt'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -132,7 +132,7 @@ module.exports = function (grunt) {
                     specs: 'mocha/mocha-test*.js',
                     mutate: 'mocha/script*.js',
                     ignore: /^\s*log\(/,
-                    discardReplacements: [/^console$/],
+                    ignoreReplacement: [/^console$/],
                     reporters: {
                         text: {
                             file: 'mocha.txt'
@@ -145,7 +145,7 @@ module.exports = function (grunt) {
                     code: 'karma-mocha/script*.js',
                     specs: ['karma-mocha/karma-test.js', 'karma-mocha/karma-endlessLoop-test.js', 'karma-mocha/karma-update-expressions-test.js', 'karma-mocha/karma-mathoperators-test.js'],
                     mutate: 'karma-mocha/script*.js',
-                    discardReplacements: ['console'],
+                    ignoreReplacement: ['^console$'],
                     testFramework: 'karma',
                     karma: {
                         frameworks: ['mocha', 'chai'],
@@ -177,7 +177,7 @@ module.exports = function (grunt) {
                     code: ['mocha/arguments.js', '../../node_modules/lodash/**/*', chaiCode],
                     specs: 'mocha/arguments-test.js',
                     mutate: 'mocha/arguments.js',
-                    discardReplacements: /^_$/,
+                    ignoreReplacement: /^_$/,
                     reporters: {
                         text: {
                             file: 'arguments.txt'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -237,7 +237,7 @@ module.exports = function (grunt) {
                     code: ['mocha/unaryExpression.js', chaiCode],
                     specs: 'mocha/unaryExpression-test.js',
                     mutate: 'mocha/unaryExpression.js',
-                    mutateStrictModeKeyword: true,
+                    discardDefaultIgnore: true,
                     reporters: {
                         text: {
                             file: 'unaryExpression.txt'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -131,7 +131,7 @@ module.exports = function (grunt) {
                     code: 'mocha/script*.js',
                     specs: 'mocha/mocha-test*.js',
                     mutate: 'mocha/script*.js',
-                    ignore: /^log\(/,
+                    ignore: /^\s*log\(/,
                     discardReplacements: [/^console$/],
                     reporters: {
                         text: {

--- a/README.md
+++ b/README.md
@@ -150,8 +150,11 @@ The maximum reported length of the mutation that has been done. When set to `0`,
 ##### options.ignore
 _optional_
 Type: `String` or `RegExp` or `[String and/or RegExp]`
+Default: `/('use strict'|"use strict");/`
 
 Code that matches with any of the supplied regular expressions will not be mutated in any way.
+
+Note that, by default, mutations on the strict mode keyword `'use strict'` will be ignored. If you really do want to mutate it, this can be done by providing the `options.mutateStrictModeKeyword` option (see below).
 
 ##### options.ignoreReplacement
 _optional_
@@ -173,6 +176,15 @@ Default: `false`
 When true, code is not copied to a temporary directory and mutated there, but instead the original production code is mutated, which can speed up your tests.
 
 _Be careful when using this option_, as, in case the mutation process does not exit correctly, your code will be left mutated.
+
+##### options.mutateStrictModeKeyword
+_optional_
+Type: `Boolean`
+Default: `false`
+
+When true, the strict mode keyword `'use strict'` will be mutated, despite the fact that it is excluded in `options.ignore`.
+
+We do not really see any relevant use case for this, but did not want to make it impossible to perform certain mutations either. Hence the existence of this configuration option.
 
 ##### options.test
 _optional_

--- a/README.md
+++ b/README.md
@@ -149,29 +149,36 @@ The maximum reported length of the mutation that has been done. When set to `0`,
 
 ##### options.ignore
 _optional_
-Type: `RegExp` or `[RegExp]`
+Type: `String` or `RegExp` or `[String and/or RegExp]`
 
-Mutated code which matches this option is ignored.
+Code that matches with any of the supplied regular expressions will not be mutated in any way.
+
+##### options.ignoreReplacement
+_optional_
+Type: `String` or `RegExp` or `[String and/or RegExp]`
+
+Mutation replacements that match with any of the supplied regular expressions will not be introduced.
 
 ##### options.excludeMutations
 _optional_
 Type: `Object`
 
-A set indicating if a mutation should be excluded.
+A set of properties, indicating whether certain mutations should be excluded for all files. See below for a list of available mutations.
 
 ##### options.mutateProductionCode
+_optional_
 Type: `Boolean`
-Default value: false
+Default: `false`
 
 When true, code is not copied to a temporary directory and mutated there, but instead the original production code is mutated, which can speed up your tests.
 
 _Be careful when using this option_, as, in case the mutation process does not exit correctly, your code will be left mutated.
 
 ##### options.test
-Type: `String` or `Function` 
-Default value: No Default value
+_optional_
+Type: `String` or `Function`
 
-This test is executed for every Mutation. If it succeeds, this mutation is reported.
+This test is executed for every Mutation. If it passes, this mutation is reported as 'survived'.
 
 
 ### Usage Examples

--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Default: `/('use strict'|"use strict");/`
 
 Code that matches with any of the supplied regular expressions will not be mutated in any way.
 
-Note that, by default, mutations on the strict mode keyword `'use strict'` will be ignored. If you really do want to mutate it, this can be done by providing the `options.mutateStrictModeKeyword` option (see below).
+Note that, by default, mutations on the strict mode keyword `'use strict'` will be ignored. If you really do want to mutate it, this can be done by providing the `options.discardDefaultIgnore` option (see below).
 
 ##### options.ignoreReplacement
 _optional_
@@ -177,12 +177,12 @@ When true, code is not copied to a temporary directory and mutated there, but in
 
 _Be careful when using this option_, as, in case the mutation process does not exit correctly, your code will be left mutated.
 
-##### options.mutateStrictModeKeyword
+##### options.discardDefaultIgnore
 _optional_
 Type: `Boolean`
 Default: `false`
 
-When true, the strict mode keyword `'use strict'` will be mutated, despite the fact that it is excluded in `options.ignore`.
+When true, mutations that are ignored by default (see `options.ignore`, above) will no longer be ignored.
 
 We do not really see any relevant use case for this, but did not want to make it impossible to perform certain mutations either. Hence the existence of this configuration option.
 

--- a/test/expected/arguments.txt
+++ b/test/expected/arguments.txt
@@ -2,4 +2,4 @@ mocha/arguments.js:4:23 Replaced _.pluck(persons, 'name') with "MUTATION!" -> SU
 mocha/arguments.js:4:49 Replaced name with "MUTATION!" -> SURVIVED
 mocha/arguments.js:4:31 Replaced persons with "MUTATION!" -> SURVIVED
 mocha/arguments.js:4:40 Replaced 'name' with "MUTATION!" -> SURVIVED
-8 of 12 unignored mutations are tested (66%).
+6 of 10 unignored mutations are tested (60%). 2 mutations were ignored.

--- a/test/expected/karma.txt
+++ b/test/expected/karma.txt
@@ -21,4 +21,4 @@ karma-mocha/script1.js:15:9 Removed console.log(sum); -> SURVIVED
 karma-mocha/script1.js:14:18 Replaced  +  with - -> SURVIVED
 karma-mocha/script1.js:15:21 Replaced sum with "MUTATION!" -> SURVIVED
 karma-mocha/script1.js:15:9 Replaced console.log(sum) with sum -> SURVIVED
-76 of 99 unignored mutations are tested (76%).
+75 of 98 unignored mutations are tested (76%). 1 mutations were ignored.

--- a/test/expected/mocha.txt
+++ b/test/expected/mocha.txt
@@ -6,4 +6,4 @@ mocha/script1.js:14:17 Replaced sum with "MUTATION!" -> SURVIVED
 mocha/script1.js:14:5 Replaced console.log(sum) with sum -> SURVIVED
 mocha/script2.js:5:5 Removed array = array; -> SURVIVED
 mocha/script2.js:6:9 Replaced array with "MUTATION!" -> SURVIVED
-29 of 37 unignored mutations are tested (78%). 3 mutations were ignored.
+28 of 36 unignored mutations are tested (77%). 4 mutations were ignored.

--- a/test/expected/mocha.txt
+++ b/test/expected/mocha.txt
@@ -6,4 +6,4 @@ mocha/script1.js:14:17 Replaced sum with "MUTATION!" -> SURVIVED
 mocha/script1.js:14:5 Replaced console.log(sum) with sum -> SURVIVED
 mocha/script2.js:5:5 Removed array = array; -> SURVIVED
 mocha/script2.js:6:9 Replaced array with "MUTATION!" -> SURVIVED
-30 of 38 unignored mutations are tested (78%). 2 mutations were ignored.
+29 of 37 unignored mutations are tested (78%). 3 mutations were ignored.

--- a/test/expected/unaryExpression.txt
+++ b/test/expected/unaryExpression.txt
@@ -1,7 +1,9 @@
-mocha/unaryExpression.js:2:18 Removed - -> SURVIVED
-mocha/unaryExpression.js:6:15 Removed - -> SURVIVED
-mocha/unaryExpression.js:10:15 Removed ~ -> SURVIVED
-mocha/unaryExpression.js:14:16 Removed ! -> SURVIVED
-mocha/unaryExpression.js:18:17 Removed - -> SURVIVED
-mocha/unaryExpression.js:22:17 Removed ! -> SURVIVED
-18 of 24 unignored mutations are tested (75%).
+mocha/unaryExpression.js:1:1 Removed 'use strict'; -> SURVIVED
+mocha/unaryExpression.js:1:1 Replaced 'use strict' with "MUTATION!" -> SURVIVED
+mocha/unaryExpression.js:3:18 Removed - -> SURVIVED
+mocha/unaryExpression.js:7:15 Removed - -> SURVIVED
+mocha/unaryExpression.js:11:15 Removed ~ -> SURVIVED
+mocha/unaryExpression.js:15:16 Removed ! -> SURVIVED
+mocha/unaryExpression.js:19:17 Removed - -> SURVIVED
+mocha/unaryExpression.js:23:17 Removed ! -> SURVIVED
+18 of 26 unignored mutations are tested (69%).

--- a/test/fixtures/mocha/unaryExpression.js
+++ b/test/fixtures/mocha/unaryExpression.js
@@ -1,3 +1,4 @@
+'use strict';
 function getBinaryExpression() {
     return -(6*7);
 }

--- a/utils/OptionUtils.js
+++ b/utils/OptionUtils.js
@@ -35,6 +35,9 @@ var DEFAULT_REPORTER = {
     console: true
 };
 
+// By default, always ignore mutations of the 'use strict' keyword
+var DEFAULT_IGNORE = /('use strict'|"use strict");/;
+
 // The code, specs and mutate options need to be configured to be able to perform the mutation tests
 var REQUIRED_OPTIONS = ['code', 'specs', 'mutate'];
 
@@ -48,6 +51,20 @@ function areRequiredOptionsSet(opts) {
     return !_.find(REQUIRED_OPTIONS, function(option) {
         return !opts.hasOwnProperty(option);
     });
+}
+
+function ensureReportersConfig(opts) {
+    // Only set the default reporter when no explicit reporter configuration is provided
+    if(!opts.hasOwnProperty('reporters')) {
+        opts.reporters = DEFAULT_REPORTER;
+    }
+}
+
+function ensureIgnoreConfig(opts) {
+    // Ignore the strict mode keyword mutations, unless the mutateStrictModeKeyword option has been provided
+    if(!opts.mutateStrictModeKeyword) {
+        opts.ignore  = opts.ignore ? [DEFAULT_IGNORE].concat(opts.ignore) : DEFAULT_IGNORE;
+    }
 }
 
 /**
@@ -107,10 +124,8 @@ function getOptions(grunt, task) {
     opts.specs = expandFiles(opts.specs, opts.basePath);
     opts.mutate = expandFiles(opts.mutate, opts.basePath);
 
-    // Only set the default reporter when no explicit reporter configuration is provided
-    if(!opts.hasOwnProperty('reporters')) {
-        opts.reporters = DEFAULT_REPORTER;
-    }
+    ensureReportersConfig(opts);
+    ensureIgnoreConfig(opts);
 
     return opts;
 }

--- a/utils/OptionUtils.js
+++ b/utils/OptionUtils.js
@@ -61,8 +61,7 @@ function ensureReportersConfig(opts) {
 }
 
 function ensureIgnoreConfig(opts) {
-    // Ignore the strict mode keyword mutations, unless the mutateStrictModeKeyword option has been provided
-    if(!opts.mutateStrictModeKeyword) {
+    if(!opts.discardDefaultIgnore) {
         opts.ignore = opts.ignore ? [DEFAULT_IGNORE].concat(opts.ignore) : DEFAULT_IGNORE;
     }
 }

--- a/utils/OptionUtils.js
+++ b/utils/OptionUtils.js
@@ -63,7 +63,7 @@ function ensureReportersConfig(opts) {
 function ensureIgnoreConfig(opts) {
     // Ignore the strict mode keyword mutations, unless the mutateStrictModeKeyword option has been provided
     if(!opts.mutateStrictModeKeyword) {
-        opts.ignore  = opts.ignore ? [DEFAULT_IGNORE].concat(opts.ignore) : DEFAULT_IGNORE;
+        opts.ignore = opts.ignore ? [DEFAULT_IGNORE].concat(opts.ignore) : DEFAULT_IGNORE;
     }
 }
 


### PR DESCRIPTION
+ ignore now works for multi-line regexes
+ mutations are now ignored also when they cover only a part of the ignored code, or more than just the ignored code
+ re-implemented discardReplacements as ignoreReplacement, which can be used to ignore certain mutation replacements (I didn't even know we could do this)
+ Ignored replacements now also count as ignored mutations
+ 'use strict' is now ignored by default (as requested in #18)
+ Added mutateStrictModeKeyword config option, in case 'use strict'; _must_ be mutated
+ Added documentation for all this in README