### PR TITLE
#41 Added extra check if any specs could be found for current file.

### DIFF
--- a/lib/reporting/html/templates/file.hbs
+++ b/lib/reporting/html/templates/file.hbs
@@ -23,7 +23,15 @@
             </tbody>
         </table>
     {{ else }}
-        <p>No mutations could be performed on this file</p>
+        <p>
+            No mutations could be performed on this file. This may be due to one of the following reasons:
+        </p>
+        <ul>
+            <li>No unit tests exist for this file</li>
+            <li>No specs were configured for this file</li>
+            <li>Unit tests are failing already without applying any mutations</li>
+            <li>All possible mutations in this file were excluded</li>
+        </ul>
     {{/if}}
 </section>
 

--- a/tasks/mutation-testing-karma.js
+++ b/tasks/mutation-testing-karma.js
@@ -110,12 +110,17 @@ exports.init = function(grunt, opts) {
             return IOUtils.normalizeWindowsPath(opts.currentFile).indexOf(file) !== -1;
         });
 
-        karmaConfig.files = _.union(opts.code, currentFileSpecs);
+        if(currentFileSpecs && currentFileSpecs.length) {
+            karmaConfig.files = _.union(opts.code, currentFileSpecs);
 
-        startServer(karmaConfig, function(instance) {
-            currentInstance = instance;
-            done();
-        });
+            startServer(karmaConfig, function(instance) {
+                currentInstance = instance;
+                done(true);
+            });
+        } else {
+            logger.warn('Could not find specs for file: %s', path.resolve(opts.currentFile));
+            done(false);
+        }
     };
 
     opts.test = function(done) {


### PR DESCRIPTION
+ Logging this to console (warning), and text and HTML reports;
+ Fixed 'tests fail without mutations' not reported in HTML report;
+ Expanded on the 'No mutations could be performed on this file' note in the HTML report.